### PR TITLE
docs: fix example cURL request for Windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,7 +393,7 @@
               <div class="doc-examples">
                 <section>
                   <h5>Example request</h5>
-                  <!-- <div class="hljs"> --><pre><code>curl -H 'content-type':'application/json' -H 'X-Api-Key':'{yourAPIkey}' -X GET https://api.clockify.me/api/workspaces/{workspaceId}/timeEntries/</code></pre>
+                  <!-- <div class="hljs"> --><pre><code>curl -H "content-type: application/json" -H "X-Api-Key: {yourAPIkey}" -X GET https://api.clockify.me/api/workspaces/{workspaceId}/timeEntries/</code></pre>
                   <!-- </div> -->
                 </section>
               </div>


### PR DESCRIPTION
This cURL request syntax also cover the cURL for Windows utility.

If we try the current command with cURL for Windows:
```bash
curl -H 'content-type':'application/json' -H 'X-Api-Key':'{yourAPIkey}' -X GET https://api.clockify.me/api/workspaces/{workspaceId}/timeEntries/
```
It will result to:
```
{"message":"Full authentication is required to access this resource","code":1000}
```
Which means the X-Api-Key is not correctly set.

Whereas with the following syntax:
```bash
curl -H "content-type: application/json" -H "X-Api-Key: {yourAPIkey}" -X GET https://api.clockify.me/api/workspaces/{workspaceId}/timeEntries/
```
It results to the right output for cURL for Windows (and also for the other OSes).